### PR TITLE
Added support for AUR4

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -251,7 +251,7 @@ def ChangeDirectoryOwner(username, directory):
 def AurInstall(name=None, pkbuild_url=None):
   CreateBuildUser()
   if name:
-    pkbuild_url = 'https://aur.archlinux.org/packages/%s/%s/PKGBUILD' % (name.lower()[:2], name.lower())
+    pkbuild_url = 'https://aur.archlinux.org/cgit/aur.git/plain/PKGBUILD?h=%s' % name.lower()
   workspace_dir = CreateTempDirectory()
   DownloadFile(pkbuild_url, os.path.join(workspace_dir, 'PKGBUILD'))
   ChangeDirectoryOwner(BUILDER_USER, workspace_dir)


### PR DESCRIPTION
Arch now uses Git for managing PKGBUILD files.

This uses the cgit web interface to download the plain text PKGBUILD file.
It's sort of a hack, and it might be better to actually checkout the PKGBUILD git repo but this requires only a single line change.